### PR TITLE
Fix export issue replacing .show_double_sided to .use_mirror_topology

### DIFF
--- a/iqm_import.py
+++ b/iqm_import.py
@@ -659,7 +659,7 @@ def make_mesh_data(iqmodel, name, meshes, amtobj, dir):
 	link_object(obj)
 
 	# Set the mesh to single-sided to spot normal errors
-	# mesh.show_double_sided = False modded
+	mesh.use_mirror_topology = False
 
 	has_vn = len(iqmodel.meshes[0].vn) > 0
 	has_vt = len(iqmodel.meshes[0].vt) > 0


### PR DESCRIPTION
A proper replacement of  `mesh.show_double_sided` by @LegendaryGuard, see: 

- https://github.com/LegendaryGuard/asstools/commit/19d5cf41a838220d204de52f4987de2f07bbb730